### PR TITLE
Add known cheaters to mute list

### DIFF
--- a/tf2_bot_detector/Config/PlayerListJSON.h
+++ b/tf2_bot_detector/Config/PlayerListJSON.h
@@ -80,7 +80,9 @@ namespace tf2_bot_detector
 	class PlayerListJSON final
 	{
 	public:
-		PlayerListJSON(const Settings& settings);
+		using PlayerMap_t = std::map<SteamID, PlayerListData>;
+		
+                PlayerListJSON(const Settings& settings);
 
 		bool LoadFiles();
 		void SaveFile() const;
@@ -103,9 +105,9 @@ namespace tf2_bot_detector
 		ModifyPlayerResult ModifyPlayer(const SteamID& id, ModifyPlayerAction(*func)(PlayerListData& data, const void* userData),
 			const void* userData = nullptr);
 
+                const PlayerMap_t& GetOfficialPlayerList() const { return m_OfficialPlayerList; };
+                const PlayerMap_t& GetOtherPlayerLists() const { return m_OtherPlayerLists; };
 	private:
-		using PlayerMap_t = std::map<SteamID, PlayerListData>;
-
 		bool LoadFile(const std::filesystem::path& filename, PlayerMap_t& map) const;
 
 		bool IsOfficial() const;

--- a/tf2_bot_detector/MainWindow.cpp
+++ b/tf2_bot_detector/MainWindow.cpp
@@ -6,6 +6,7 @@
 #include "PeriodicActions.h"
 #include "Log.h"
 #include "PathUtils.h"
+#include "VoiceBanUtils.h"
 
 #include <imgui_desktop/ScopeGuards.h>
 #include <imgui_desktop/ImGuiHelpers.h>
@@ -27,7 +28,8 @@ using namespace std::string_view_literals;
 
 MainWindow::MainWindow() :
 	ImGuiDesktop::Window(800, 600, "TF2 Bot Detector"),
-	m_ActionManager(m_Settings)
+	m_ActionManager(m_Settings),
+        m_VoiceBanUtils(m_Settings)
 {
 	m_OpenTime = clock_t::now();
 
@@ -531,6 +533,34 @@ void MainWindow::OnDrawSettingsPopup()
 			if (ImGui::IsItemHovered())
 				ImGui::SetTooltip("Automatically, temporarily mute ingame chat messages if we think someone else in the server is running the tool.");
 		}
+
+                // Add cheaters to mute list
+                {
+                        ImGui::Separator();
+
+                        if(ImGui::Button("Voice ban known cheaters in TF2")) {
+                            ImGui::OpenPopup("Voice Ban Warning");
+                        }
+
+                        if (ImGui::BeginPopupModal("Voice Ban Warning"))
+                        {
+                            ImGui::Text("This button must be used before starting TF2; it will have no effect while TF2 is running. Continue?");
+                            
+                            if (ImGui::Button("Continue")) {
+                                m_VoiceBanUtils.ReadVoiceBans();
+                                m_VoiceBanUtils.BanCheaters();
+                                m_VoiceBanUtils.WriteVoiceBans();
+
+                                ImGui::CloseCurrentPopup();
+                            }
+
+                            if (ImGui::Button("Cancel"))
+                                ImGui::CloseCurrentPopup();
+
+                            ImGui::EndPopup();
+                        }
+
+                }
 
 		ImGui::EndPopup();
 	}

--- a/tf2_bot_detector/MainWindow.h
+++ b/tf2_bot_detector/MainWindow.h
@@ -13,6 +13,7 @@
 #include "PlayerStatus.h"
 #include "TFConstants.h"
 #include "IConsoleLineListener.h"
+#include "VoiceBanUtils.h"
 
 #include <imgui_desktop/Window.h>
 
@@ -156,5 +157,6 @@ namespace tf2_bot_detector
 		Settings m_Settings;
 		ActionManager m_ActionManager;
 		SetupFlow m_SetupFlow;
+                VoiceBanUtils m_VoiceBanUtils;
 	};
 }

--- a/tf2_bot_detector/VoiceBanUtils.cpp
+++ b/tf2_bot_detector/VoiceBanUtils.cpp
@@ -68,7 +68,7 @@ bool VoiceBanUtils::WriteVoiceBans()
 bool VoiceBanUtils::IsBanned(const tf2_bot_detector::SteamID& id)
 {
     char searchString[SIGNED_GUID_LEN] = {0};
-    strcpy_s(searchString, SIGNED_GUID_LEN, id.str().c_str());
+    memcpy(searchString, id.str().c_str(), id.str().length());
 
     for (VoiceBanPlayerID playerId : m_BanList) {
         if (strcmp(searchString, playerId.guid) == 0)
@@ -85,7 +85,7 @@ bool VoiceBanUtils::MarkBan(const tf2_bot_detector::SteamID& id)
     VoiceBanPlayerID playerId;
 
     memset(playerId.guid, 0, SIGNED_GUID_LEN);
-    strcpy_s(playerId.guid, SIGNED_GUID_LEN, id.str().c_str());
+    memcpy(playerId.guid, id.str().c_str(), id.str().length());
 
     m_BanList.push_back(playerId);
 

--- a/tf2_bot_detector/VoiceBanUtils.cpp
+++ b/tf2_bot_detector/VoiceBanUtils.cpp
@@ -1,0 +1,94 @@
+#include "VoiceBanUtils.h"
+
+using namespace std;
+using namespace tf2_bot_detector;
+
+VoiceBanUtils::VoiceBanUtils(const Settings& settings)
+    : m_Settings(&settings)
+    , m_BanList()
+{
+    m_VoiceDataPath = m_Settings->m_TFDir / "voice_ban.dt";
+}
+
+bool VoiceBanUtils::ReadVoiceBans()
+{
+    ifstream voiceDataFile(m_VoiceDataPath, ios::binary);
+    if (!voiceDataFile.good()) {
+        LogWarning(std::string(__FUNCTION__ ": Failed to open voice_ban.dt"));
+        return false;
+    }
+
+    int version;
+    voiceDataFile.read((char*)&version, sizeof(version));
+
+    if (version != BANMGR_FILEVERSION) {
+        LogWarning(std::string(__FUNCTION__ ": Version mismatch"));
+        return false;
+    }
+
+    int contentSize = std::filesystem::file_size(m_VoiceDataPath) - sizeof(version);
+    int idsToRead = contentSize / SIGNED_GUID_LEN;
+
+    m_BanList = std::vector<VoiceBanPlayerID>();
+
+    while (idsToRead > 0) {
+        VoiceBanPlayerID playerId;
+        voiceDataFile.read(playerId.guid, SIGNED_GUID_LEN);
+		//Log(std::string(playerId.guid));
+        m_BanList.push_back(playerId);
+        idsToRead--; 
+    }
+
+    voiceDataFile.close();
+
+    return true;
+}
+
+bool VoiceBanUtils::WriteVoiceBans()
+{
+    ofstream voiceDataFile(m_VoiceDataPath, ios::binary);
+    if (!voiceDataFile.good()) {
+        LogWarning(std::string(__FUNCTION__ ": Failed to open voice_ban.dt"));    
+        return false;
+    }
+
+    int version = BANMGR_FILEVERSION;
+    voiceDataFile.write((char*)&version, sizeof(version));
+
+    for (VoiceBanPlayerID playerId : m_BanList) {
+        voiceDataFile.write(playerId.guid, SIGNED_GUID_LEN);
+    }
+
+    voiceDataFile.close();
+
+    return true;
+}
+
+bool VoiceBanUtils::IsBanned(const tf2_bot_detector::SteamID& id)
+{
+    char searchString[32] = {0};
+    strcpy_s(searchString, id.str().c_str());
+
+    for (VoiceBanPlayerID playerId : m_BanList) {
+        if (strcmp(searchString, playerId.guid) == 0)
+            return true;
+    }
+
+    return false;     
+}
+
+bool VoiceBanUtils::MarkBan(const tf2_bot_detector::SteamID& id)
+{
+    if (IsBanned(id)) return false;
+
+    VoiceBanPlayerID playerId;
+    const char* guid = id.str().c_str();
+
+    memset(playerId.guid, 0, SIGNED_GUID_LEN);
+    strcpy_s(playerId.guid, guid);
+
+    m_BanList.push_back(playerId);
+
+    return true;
+}
+

--- a/tf2_bot_detector/VoiceBanUtils.h
+++ b/tf2_bot_detector/VoiceBanUtils.h
@@ -1,13 +1,17 @@
 #pragma once
 
 #include "Config/Settings.h"
+#include "Config/PlayerListJSON.h"
 #include "Log.h"
 #include "SteamID.h"
 
 #include <filesystem>
 #include <fstream>
-#include <vector>
+#include <list>
 #include <cstring>
+
+#include <mh/text/case_insensitive_string.hpp>
+#include <mh/text/string_insertion.hpp>
 
 #define BANMGR_FILEVERSION 1
 #define SIGNED_GUID_LEN 32
@@ -26,10 +30,13 @@ namespace tf2_bot_detector
 		bool WriteVoiceBans();
 		bool IsBanned(const tf2_bot_detector::SteamID& id);
 		bool MarkBan(const tf2_bot_detector::SteamID& id);
+
+                void BanCheaters();
 	private:
 		const Settings* m_Settings = nullptr;
+                PlayerListJSON m_PlayerList;
 		std::filesystem::path m_VoiceDataPath;
 
-		std::vector<VoiceBanPlayerID> m_BanList;
+		std::list<VoiceBanPlayerID> m_BanList;
 	};
 }

--- a/tf2_bot_detector/VoiceBanUtils.h
+++ b/tf2_bot_detector/VoiceBanUtils.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Config/Settings.h"
+#include "Log.h"
+#include "SteamID.h"
+
+#include <filesystem>
+#include <fstream>
+#include <vector>
+#include <cstring>
+
+#define BANMGR_FILEVERSION 1
+#define SIGNED_GUID_LEN 32
+
+namespace tf2_bot_detector
+{
+	typedef struct {
+		char guid[SIGNED_GUID_LEN];
+	} VoiceBanPlayerID;
+
+	class VoiceBanUtils
+	{
+	public:
+		VoiceBanUtils(const Settings& settings);
+		bool ReadVoiceBans();
+		bool WriteVoiceBans();
+		bool IsBanned(const tf2_bot_detector::SteamID& id);
+		bool MarkBan(const tf2_bot_detector::SteamID& id);
+	private:
+		const Settings* m_Settings = nullptr;
+		std::filesystem::path m_VoiceDataPath;
+
+		std::vector<VoiceBanPlayerID> m_BanList;
+	};
+}

--- a/tf2_bot_detector/tf2_bot_detector.vcxproj
+++ b/tf2_bot_detector/tf2_bot_detector.vcxproj
@@ -98,6 +98,7 @@
     <ClCompile Include="PlatformSpecific\Windows\Shell.cpp" />
     <ClCompile Include="SetupFlow.cpp" />
     <ClCompile Include="SteamID.cpp" />
+    <ClCompile Include="VoiceBanUtils.cpp" />
     <ClCompile Include="WorldState.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -130,6 +131,7 @@
     <ClInclude Include="SetupFlow.h" />
     <ClInclude Include="SteamID.h" />
     <ClInclude Include="TFConstants.h" />
+    <ClInclude Include="VoiceBanUtils.h" />
     <ClInclude Include="WorldState.h" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Adds a button to the Settings panel that, when pressed, will add players that are marked cheaters to TF2's `voice_ban.dt`.

Fixes #13.

**TODO:**
- [x] Glue code: Add button to sync cheater IDs to mute list
- [x] Add warning (must sync before starting game)
- [x] Update .vcxproj