### PR TITLE
Add a racist bot SteamID

### DIFF
--- a/staging/cfg/playerlist.official.json
+++ b/staging/cfg/playerlist.official.json
@@ -11,6 +11,12 @@
 	"players": [
 		{
 			"attributes": [
+				"racist"
+			],
+			"steamid": "[U:1:948219720]"
+		},
+		{
+			"attributes": [
 				"cheater"
 			],
 			"last_seen": {


### PR DESCRIPTION
Usually has a youtube link as a username (i.e. "youtube.com/watch?v=KDhsaKzXcuo")