### PR TITLE
add chat warning delay option

### DIFF
--- a/tf2_bot_detector/Config/Settings.cpp
+++ b/tf2_bot_detector/Config/Settings.cpp
@@ -220,6 +220,7 @@ void Settings::LoadFile()
 		try_get_to_defaulted(*found, m_AutoChatWarningsConnecting, "auto_chat_warnings_connecting", DEFAULTS.m_AutoChatWarningsConnecting);
 		try_get_to_defaulted(*found, m_AutoVotekick, "auto_votekick", DEFAULTS.m_AutoVotekick);
 		try_get_to_defaulted(*found, m_AutoVotekickDelay, "auto_votekick_delay", DEFAULTS.m_AutoVotekickDelay);
+		try_get_to_defaulted(*found, m_ChatWarningInterval, "chat_warning_interval", DEFAULTS.m_ChatWarningInterval);
 		try_get_to_defaulted(*found, m_AutoMark, "auto_mark", DEFAULTS.m_AutoMark);
 		try_get_to_defaulted(*found, m_LazyLoadAPIData, "lazy_load_api_data", DEFAULTS.m_LazyLoadAPIData);
 

--- a/tf2_bot_detector/Config/Settings.h
+++ b/tf2_bot_detector/Config/Settings.h
@@ -56,6 +56,7 @@ namespace tf2_bot_detector
 		bool m_AutoChatWarningsConnecting = false;
 		bool m_AutoVotekick = true;
 		float m_AutoVotekickDelay = 15;
+		float m_ChatWarningInterval = 20;
 		bool m_AutoMark = true;
 
 		bool m_SleepWhenUnfocused = true;
@@ -67,6 +68,7 @@ namespace tf2_bot_detector
 		ProgramUpdateCheckMode m_ProgramUpdateCheckMode = ProgramUpdateCheckMode::Unknown;
 
 		constexpr auto GetAutoVotekickDelay() const { return std::chrono::duration<float>(m_AutoVotekickDelay); }
+		constexpr auto GetChatWarningInterval() const { return std::chrono::milliseconds((int)(m_ChatWarningInterval * 1000)); }
 
 		const std::string& GetSteamAPIKey() const { return m_SteamAPIKey; }
 		void SetSteamAPIKey(std::string key);

--- a/tf2_bot_detector/ModeratorLogic.cpp
+++ b/tf2_bot_detector/ModeratorLogic.cpp
@@ -425,7 +425,7 @@ void ModeratorLogic::HandleConnectedEnemyCheaters(const std::vector<Cheater>& en
 			if (m_Settings->m_AutoChatWarnings && m_ActionManager->QueueAction<ChatMessageAction>(chatMsg))
 			{
 				Log({ 1, 0, 0, 1 }, logMsg);
-				m_NextCheaterWarningTime = now + CHEATER_WARNING_INTERVAL;
+				m_NextCheaterWarningTime = now + m_Settings->GetChatWarningInterval();
 			}
 		}
 		else

--- a/tf2_bot_detector/UI/MainWindow.cpp
+++ b/tf2_bot_detector/UI/MainWindow.cpp
@@ -235,6 +235,14 @@ void MainWindow::OnDrawSettingsPopup()
 					"This is needed because players can't vote until they have joined a team and picked a class. If we call a vote before enough people are ready, it might fail.");
 			}
 
+			// Chat warning interval
+			{
+				if (ImGui::SliderFloat("Chat warning interval", &m_Settings.m_ChatWarningInterval, 20, 60, "%1.1f seconds"))
+					m_Settings.SaveFile();
+				ImGui::SetHoverTooltip("Interval between chat warnings.\n\n"
+					"Increase it if you feel that you are spamming too much.");
+			}
+
 			// Send warnings for connecting cheaters
 			{
 				if (ImGui::Checkbox("Chat message warnings for connecting cheaters", &m_Settings.m_AutoChatWarningsConnecting))


### PR DESCRIPTION
I felt motivated to study a little bit of c++ with this project (I'm a web dev), so I tried to implement and propose a simple enhancement, which was already mentioned on #187 and #70. 

The result is this option on Settings > Moderation:

![image](https://user-images.githubusercontent.com/2482730/90842050-abe5f380-e334-11ea-8b55-e3e058382ee2.png)

Min value is 20 seconds, since below that is too spammy IMO, and max is 60.

There's something I didn't manage to change though: [here](https://github.com/PazerOP/tf2_bot_detector/blob/master/tf2_bot_detector/ModeratorLogic.cpp#L113) we need to replace `CHEATER_WARNING_INTERVAL` with `m_Settings->GetChatWarningInterval()`, but I don't know how to use m_Settings here...

```
		// We also need to remove this in favor of m_Settings->GetChatWarningInterval()
		static constexpr duration_t CHEATER_WARNING_INTERVAL = std::chrono::seconds(20);

		// The soonest we can make an accusation after having seen an accusation in chat from a bot leader.
		// This must be longer than CHEATER_WARNING_INTERVAL.
		static constexpr duration_t CHEATER_WARNING_INTERVAL_NONLOCAL = CHEATER_WARNING_INTERVAL + std::chrono::seconds(10);
```