### PR TITLE
Add the ability to open on startup

### DIFF
--- a/msix/package_staging/AppxManifest.xml
+++ b/msix/package_staging/AppxManifest.xml
@@ -32,7 +32,7 @@
 					</uap:Protocol>
 				</uap:Extension>
 				<desktop:Extension Category="windows.startupTask">
-					<desktop:StartupTask TaskId="TF2BD_Startup_Task" Enabled="false" DisplayName="TF2 Bot Detector Startup Task" />
+					<desktop:StartupTask TaskId="TF2BD_Startup_Task" Enabled="false" />
 				</desktop:Extension>
 			</Extensions>
 		</Application>

--- a/msix/package_staging/AppxManifest.xml
+++ b/msix/package_staging/AppxManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
 	xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+	xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
 	xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
 	<Identity Name="tf2-bot-detectorTF2BD_PACKAGE_IDENTITY_SUFFIX_REPLACE_ME" Version="TF2BD_VERSION_REPLACE_ME" ProcessorArchitecture="TF2BD_PROCESSOR_ARCH_REPLACE_ME" Publisher="CN=Matt Haynie, O=Matt Haynie, STREET=2416 201st Ave SE, L=Sammamish, S=Washington, PostalCode=98075, C=US" />
 	<Properties>
@@ -30,6 +31,9 @@
 						<uap:DisplayName>TF2 Bot Detector URI Handler</uap:DisplayName>
 					</uap:Protocol>
 				</uap:Extension>
+				<desktop:Extension Category="windows.startupTask">
+					<desktop:StartupTask TaskId="TF2BD_Startup_Task" Enabled="false" DisplayName="TF2 Bot Detector Startup Task" />
+				</desktop:Extension>
 			</Extensions>
 		</Application>
 	</Applications>


### PR DESCRIPTION
Adds the ability to the installed version to open the tool on system startup (not sure why you would want to, but...)

For the portable version, just add a shortcut to the "Startup" folder, or use a scheduled task.

Closes #295.