### PR TITLE
Change UI to correctly represent Steam ID3 and not Steam ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ When you first run the tool it will ask if you would like to allow internet conn
 
 It is **strongly** recommended to set up your Steam Web API key. More information can be found [here][api-wiki].
 
-> Note: If TF2BD is unable to find your Steam folder, your TF2's tf folder, or your Steam ID, it will ask you for the missing information before anything else
+> Note: If TF2BD is unable to find your Steam folder, your TF2's tf folder, or your Steam ID3, it will ask you for the missing information before anything else
 
 ### Using TF2BD
 

--- a/tf2_bot_detector/Config/AccountAges.cpp
+++ b/tf2_bot_detector/Config/AccountAges.cpp
@@ -44,7 +44,7 @@ bool AccountAges::CheckSteamIDValid(const SteamID& id, const mh::source_location
 {
 	if (id.Type != SteamAccountType::Individual)
 	{
-		LogError(location, "Steam ID ({}) must be for an individual account", id);
+		LogError(location, "Steam ID3 ({}) must be for an individual account", id);
 		return false;
 	}
 

--- a/tf2_bot_detector/Config/AccountAges.cpp
+++ b/tf2_bot_detector/Config/AccountAges.cpp
@@ -79,7 +79,7 @@ std::optional<time_point_t> AccountAges::EstimateAccountCreationTime(const Steam
 	if (lower->m_CreationTime == upper->m_CreationTime)
 		return lower->m_CreationTime;  // they're the same picture
 
-	// Interpolate the time between the nearest lower and upper steam ID
+	// Interpolate the time between the nearest lower and upper steam ID3
 	const auto interpValue = mh::remap(id.GetAccountID(),
 		lower->m_SteamID.GetAccountID(), upper->m_SteamID.GetAccountID(),
 		lower->m_CreationTime.time_since_epoch().count(), upper->m_CreationTime.time_since_epoch().count());

--- a/tf2_bot_detector/Config/Rules.h
+++ b/tf2_bot_detector/Config/Rules.h
@@ -75,7 +75,7 @@ namespace tf2_bot_detector
 		struct Actions
 		{
 			std::vector<PlayerAttribute> m_Mark;
-			std::vector<PlayerAttribute> m_TransientMark; // Doesn't "stick" to their Steam ID
+			std::vector<PlayerAttribute> m_TransientMark; // Doesn't "stick" to their Steam ID3
 			std::vector<PlayerAttribute> m_Unmark;
 		} m_Actions;
 	};

--- a/tf2_bot_detector/ModeratorLogic.cpp
+++ b/tf2_bot_detector/ModeratorLogic.cpp
@@ -98,7 +98,7 @@ namespace
 			} m_Voice;
 		};
 
-		// Steam IDs of players that we think are running the tool.
+		// Steam ID3s of players that we think are running the tool.
 		std::unordered_set<SteamID> m_PlayersRunningTool;
 
 		void OnPlayerStatusUpdate(IWorldState& world, const IPlayer& player) override;

--- a/tf2_bot_detector/SetupFlow/BasicSettingsPage.cpp
+++ b/tf2_bot_detector/SetupFlow/BasicSettingsPage.cpp
@@ -38,7 +38,7 @@ auto BasicSettingsPage::OnDraw(const DrawState& ds) -> OnDrawResult
 		ImGui::TextFmt("Location of your Steam directory:");
 		ImGui::NewLine();
 		ImGuiDesktop::ScopeGuards::Indent indent;
-		ImGui::TextFmt("Your Steam directory is needed to execute commands in TF2, read console logs, and determine your current Steam ID.");
+		ImGui::TextFmt("Your Steam directory is needed to execute commands in TF2, read console logs, and determine your current Steam ID3.");
 
 		InputTextSteamDirOverride("##SetupFlow_SteamDir", m_Settings.m_SteamDirOverride);
 
@@ -62,10 +62,10 @@ auto BasicSettingsPage::OnDraw(const DrawState& ds) -> OnDrawResult
 	//if (!GetCurrentActiveSteamID().IsValid())
 	{
 		any = true;
-		ImGui::TextFmt("Your Steam ID:"sv);
+		ImGui::TextFmt("Your Steam ID3:"sv);
 		ImGui::NewLine();
 		ImGui::Indent();
-		ImGui::TextFmt("Your Steam ID is needed to identify who can be votekicked (same team) and who is on the other team. You can find your Steam ID using sites like steamidfinder.com.");
+		ImGui::TextFmt("Your Steam ID3 is needed to identify who can be votekicked (same team) and who is on the other team. You can find your Steam ID3 using sites like steamidfinder.com.");
 
 		InputTextSteamIDOverride("##SetupFlow_SteamID", m_Settings.m_LocalSteamIDOverride);
 

--- a/tf2_bot_detector/SetupFlow/BasicSettingsPage.cpp
+++ b/tf2_bot_detector/SetupFlow/BasicSettingsPage.cpp
@@ -58,7 +58,7 @@ auto BasicSettingsPage::OnDraw(const DrawState& ds) -> OnDrawResult
 		ImGui::Unindent();
 	}
 
-	// 2. Steam ID
+	// 2. Steam ID3
 	//if (!GetCurrentActiveSteamID().IsValid())
 	{
 		any = true;

--- a/tf2_bot_detector/UI/MainWindow.Scoreboard.cpp
+++ b/tf2_bot_detector/UI/MainWindow.Scoreboard.cpp
@@ -380,7 +380,7 @@ void MainWindow::OnDrawScoreboardRow(IPlayer& player)
 		ImGui::NextColumn();
 	}
 
-	// Steam ID column
+	// Steam ID3 column
 	{
 		const auto str = player.GetSteamID().str();
 		if (player.GetSteamID().Type != SteamAccountType::Invalid)

--- a/tf2_bot_detector/UI/MainWindow.Scoreboard.cpp
+++ b/tf2_bot_detector/UI/MainWindow.Scoreboard.cpp
@@ -111,7 +111,7 @@ void MainWindow::OnDrawScoreboard()
 
 				// SteamID header and column setup
 				{
-					ImGui::TextFmt("Steam ID");
+					ImGui::TextFmt("Steam ID3");
 					if (scoreboardResized)
 					{
 						nameColumnWidth -= 100 * currentFontScale;// +ImGui::GetStyle().ItemSpacing.x * 2;
@@ -412,7 +412,7 @@ void MainWindow::OnDrawScoreboardContextMenu(IPlayer& player)
 			if (ImGui::MenuItem("In-game Name"))
 				ImGui::SetClipboardText(player.GetNameUnsafe().c_str());
 
-			if (ImGui::MenuItem("Steam ID", nullptr, false, steamID.IsValid()))
+			if (ImGui::MenuItem("Steam ID3", nullptr, false, steamID.IsValid()))
 				ImGui::SetClipboardText(steamID.str().c_str());
 
 			ImGui::EndMenu();

--- a/tf2_bot_detector/UI/SettingsWindow.cpp
+++ b/tf2_bot_detector/UI/SettingsWindow.cpp
@@ -48,7 +48,7 @@ void SettingsWindow::OnDrawASOSettings()
 			m_Settings.SaveFile();
 
 		// Local steamid
-		if (InputTextSteamIDOverride("My Steam ID", m_Settings.m_LocalSteamIDOverride, true))
+		if (InputTextSteamIDOverride("My Steam ID3", m_Settings.m_LocalSteamIDOverride, true))
 			m_Settings.SaveFile();
 
 		ImGui::TreePop();


### PR DESCRIPTION
TF2's "status" command uses Steam ID3, not Steam ID.

"Steam ID" is in the format STEAM_X:X:XXXXXXXX. TF2BD utilizes TF2's built in "status" command which is in the format of "Steam ID3" [U:X:XXXXXXXXX]. Both of these ID types contain completely different strings of numbers and are formatted differently. This pull request is a simple, small UI change to differentiate between ID and ID3 within the main UI windows.

I can understand, for simplicity sake, why it would be easier to just say "ID" rather than "ID3", but I figured it might be worth bringing up anyway...