### PR TITLE
Add myg0t.win to the official blacklist

### DIFF
--- a/staging/cfg/rules.official.json
+++ b/staging/cfg/rules.official.json
@@ -24,7 +24,8 @@
 						"MYG)T",
 						"[t0gym]",
 						"[g0tb0t]",
-						"myg0t.gg"
+						"myg0t.gg",
+						"myg0t.win"
 					]
 				}
 			}


### PR DESCRIPTION
These bots are basically the same as myg0t.gg, but they use a different name.