### PR TITLE
Add rapha. bot to the official rules

### DIFF
--- a/staging/cfg/rules.official.json
+++ b/staging/cfg/rules.official.json
@@ -574,6 +574,29 @@
 					}
 				]
 			}
+		},
+		{
+			"actions": {
+				"mark": [
+					"cheater"
+				]
+			},
+			"description": "rapha. bot",
+			"triggers": {
+				"avatar_match": [
+					{
+						"avatar_hash": "25f543efdffaa2553c16da12d87d68ff93a923cf"
+					}
+				],
+				"mode": "match_all",
+				"username_text_match": {
+					"case_sensitive": true,
+					"mode": "contains",
+					"patterns": [
+						"rapha."
+					]
+				}
+			}
 		}
 	]
 }


### PR DESCRIPTION
I got the avatar hash from here: https://steamcommunity.com/id/213123545435345345/

And this is the proof that "rapha." bots exist (I was playing a Casual match): https://www.youtube.com/watch?v=xthzCHG98DM