### PR TITLE
Add OMEGATRONIC profile picture hash to official rules.

### DIFF
--- a/staging/cfg/rules.official.json
+++ b/staging/cfg/rules.official.json
@@ -597,6 +597,21 @@
 					]
 				}
 			}
+		},
+		{
+			"actions": {
+				"mark": [
+					"cheater"
+				]
+			},
+			"description": "OMEGATRONIC",
+			"triggers": {
+				"avatar_match": [
+					{
+						"avatar_hash": "cd0f89d52d4febcdd980255e498a994b0e3a56a4"
+					}
+				]
+			}
 		}
 	]
 }


### PR DESCRIPTION
Every OMEGATRONIC bot account has the same profile picture.
Here is the SHA1 hash:
cd0f89d52d4febcdd980255e498a994b0e3a56a4
Examples:
https://steamcommunity.com/profiles/76561199165031142
https://steamcommunity.com/profiles/76561199214093868
https://steamcommunity.com/profiles/76561199214183595
https://steamcommunity.com/profiles/76561199214584021
All of these OMEGATRONIC accounts have the same exact profile picture with identical hashes.
I have been using this profile picture hash rule for weeks and it works flawlessly every time.